### PR TITLE
[delete]vender/bundle

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ end
 group :development do
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
   gem 'web-console', '>= 3.3.0'
-  gem 'listen', '>= 3.0.5', '< 3.2'
+  
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
@@ -70,7 +70,7 @@ gem 'font-awesome-sass', '~> 5.13'
 gem "refile", require: "refile/rails", github: 'manfe/refile'
 gem "refile-mini_magick"
 
-
+gem 'listen', '>= 3.0.5', '< 3.2'
 
 gem 'dotenv-rails'
 group :production do


### PR DESCRIPTION
・エラーが出たため、vender/bundleファイルを削除
・gemfileのgem 'listen'をdevelopmentの外に出す（エラーが出たため）